### PR TITLE
feat: copy semantic file

### DIFF
--- a/Alloy/commands/new/index.js
+++ b/Alloy/commands/new/index.js
@@ -45,6 +45,13 @@ module.exports = async function(args, program) {
 		}
 	});
 
+	// copy semantic.colors.json
+	var semanticFile = path.join(paths.resources, 'semantic.colors.json');
+	if (fs.existsSync(semanticFile)) {
+		var targetSemantic = path.join(paths.app, CONST.DIR.ASSETS, 'semantic.colors.json')
+		fs.copyFileSync(semanticFile, targetSemantic);
+	}
+
 	// add alloy-specific folders
 	_.each(appDirs, function(dir) {
 		fs.mkdirpSync(path.join(paths.app, dir));

--- a/Alloy/commands/new/index.js
+++ b/Alloy/commands/new/index.js
@@ -48,7 +48,7 @@ module.exports = async function(args, program) {
 	// copy semantic.colors.json
 	var semanticFile = path.join(paths.resources, 'semantic.colors.json');
 	if (fs.existsSync(semanticFile)) {
-		var targetSemantic = path.join(paths.app, CONST.DIR.ASSETS, 'semantic.colors.json')
+		var targetSemantic = path.join(paths.app, CONST.DIR.ASSETS, 'semantic.colors.json');
 		fs.copyFileSync(semanticFile, targetSemantic);
 	}
 


### PR DESCRIPTION
one part for: https://github.com/tidev/titanium_mobile/issues/13241

copying an existing semantic file when converting classic -> alloy

**Test**
* `ti create`
* create `Resources/semantic.colors.json` or use https://github.com/tidev/titanium_mobile/pull/13326
* `alloy new`
* check if `semantic.colors.json` exists in `app/assets/`