### PR TITLE
ci: add github action to publish alloy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         nodeVersion: [ '12.x' ]
         os: [ macos-latest ]
-        tiSDK: [ latest, '-b master' ] # -b master is to reduce the complexity of handling a GA install vs a branch install
+        tiSDK: [ latest ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Setup node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies
+      run: npm ci
+      if: steps.node-cache.outputs.cache-hit != 'true'
+
+    - name: Publish to npm
+      env:
+        GH_TOKEN: ${{ github.token }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing to Alloy
+
+
+## Releasing
+
+To release a new version of Alloy, please do the following:
+
+1. Ensure all changes you want in the release are merged
+2. Create a pull request that does the following:
+   1. Updates the [changelog](./CHANGELOG.md) for the release
+   2. Bumps the version in the package.json/package-lock.json as required
+3. Once that pull request is merged, [create a new release](https://github.com/tidev/alloy/releases/new) and GitHub actions will publish the new version


### PR DESCRIPTION
This adds a publish action similar to the others that will publish the alloy package when a new release is created.

I've also added a `CONTRIBUTING.md` file that describes how to do this, it totally needs fleshing out some more but maybe that can be done after the release.

It also removes the `-b latest` usage from the test matrix cos it no longer exists.