### PR TITLE
fix(android): fix proxyId crash

### DIFF
--- a/Alloy/lib/alloy/controllers/BaseController.js
+++ b/Alloy/lib/alloy/controllers/BaseController.js
@@ -418,6 +418,10 @@ The 'redbg' and 'bigger' classes are shown below:
 		 * @since 1.7.0
 		 */
 		addListener: function(proxy, type, callback) {
+			if (!proxy) {
+				return;
+			}
+
 			if (!proxy.id) {
 				proxy.id = _.uniqueId('__trackId');
 


### PR DESCRIPTION
Running 
```xml
<Alloy>
    <Window title="My Test App">
        <ActionBar id="actionbar" title="My XML Menu" onClick="onClick" />
    </Window>
</Alloy>
```

crashed with the following log:
```
[ERROR] TiExceptionHandler: (main) [76,76] /alloy/controllers/BaseController.js:421
[ERROR] TiExceptionHandler: !proxy.id&&(
[ERROR] TiExceptionHandler:        ^
[ERROR] TiExceptionHandler: TypeError: Cannot read property 'id' of undefined
[ERROR] TiExceptionHandler:     at Controller.addListener (/alloy/controllers/BaseController.js:421:8)
[ERROR] TiExceptionHandler:     at new Controller (/alloy/controllers/index.js:188:552)
[ERROR] TiExceptionHandler:     at Object.exports.createController (/alloy.js:427:8)
[ERROR] TiExceptionHandler:     at /app.js:30:7
[ERROR] TiExceptionHandler:     at Module._runScript (ti:/kroll.js:1346:15)
[ERROR] TiExceptionHandler:     at Module.load (ti:/kroll.js:829:13)
[ERROR] TiExceptionHandler:     at Module.loadJavascriptText (ti:/kroll.js:1192:15)
[ERROR] TiExceptionHandler:     at Module.loadAsFile (ti:/kroll.js:1244:22)
[ERROR] TiExceptionHandler:     at Module.loadAsFileOrDirectory (ti:/kroll.js:1163:26)
[ERROR] TiExceptionHandler:     at Module.require (ti:/kroll.js:974:30)
[ERROR] TiExceptionHandler:
[ERROR] TiExceptionHandler:     org.appcelerator.kroll.runtime.v8.V8Runtime.nativeRunModule(Native Method)
[ERROR] TiExceptionHandler:     org.appcelerator.kroll.runtime.v8.V8Runtime.doRunModule(V8Runtime.java:172)
[ERROR] TiExceptionHandler:     org.appcelerator.titanium.TiApplication.launch(TiApplication.java:875)
[ERROR] TiExceptionHandler:     org.appcelerator.titanium.TiLaunchActivity.loadScript(TiLaunchActivity.java:96)
[ERROR] TiExceptionHandler:     org.appcelerator.titanium.TiRootActivity.loadScript(TiRootActivity.java:506)
[ERROR] TiExceptionHandler:     org.appcelerator.titanium.TiLaunchActivity.onResume(TiLaunchActivity.java:177)
[ERROR] TiExceptionHandler:     org.appcelerator.titanium.TiRootActivity.onResume(TiRootActivity.java:525)
[ERROR] TiExceptionHandler:     android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1531)
[ERROR] TiExceptionHandler:     android.app.Activity.performResume(Activity.java:8422)
[ERROR] TiExceptionHandler:     android.app.ActivityThread.performResumeActivity(ActivityThread.java:4793)
```

because it is not allowed to add `onClick` to an `<ActionBar>`, there is no `proxy` in the `addListener`.

This fix will ignore it and make the app run normally. The click even is ignored