### PR TITLE
fix(all): remove getter in PickerColumn parser

### DIFF
--- a/Alloy/commands/compile/parsers/Ti.UI.PickerColumn.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.PickerColumn.js
@@ -72,7 +72,7 @@ function parse(node, state, args) {
 		}
 		code += _.template(CU.generateCollectionBindingTemplate(args))({
 			localModel: localModel,
-			pre: 'var rows=[];\n_.each(' + args.symbol + '.getRows(), function(r) { ' + args.symbol + '.removeRow(r);});\n',
+			pre: 'var rows=[];\n_.each(' + args.symbol + '.rows, function(r) { ' + args.symbol + '.removeRow(r);});\n',
 			items: rowCode,
 			post: '_.each(rows, function(row) { ' + args.symbol + '.addRow(row); });'
 		});


### PR DESCRIPTION
fixes https://github.com/tidev/alloy/issues/1348

Need to test it but it looks correct since it is using an old method instead of the getter property