### PR TITLE
feat(android): add collapseToolbar support

### DIFF
--- a/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.ContentView.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.ContentView.js
@@ -1,3 +1,11 @@
 exports.parse = function(node, state) {
+	_.extend(state, {
+		proxyPropertyDefinition: {
+			parents: [
+				'Ti.UI.Android.CollapseToolbar',
+				'Ti.UI.iPad.Popover'
+			]
+		}
+	});
 	return require('./Ti.UI.Android.CollapseToolbar._ProxyProperty').parse(node, state);
 };

--- a/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.ContentView.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.ContentView.js
@@ -1,0 +1,3 @@
+exports.parse = function(node, state) {
+	return require('./Ti.UI.Android.CollapseToolbar._ProxyProperty').parse(node, state);
+};

--- a/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar._ProxyProperty.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar._ProxyProperty.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
 exports.parse = function(node, state) {
 	_.extend(state, {

--- a/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar._ProxyProperty.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar._ProxyProperty.js
@@ -4,7 +4,7 @@ exports.parse = function(node, state) {
 	_.extend(state, {
 		proxyPropertyDefinition: {
 			parents: [
-				'Ti.UI.Android.DrawerLayout'
+				'Ti.UI.Android.CollapseToolbar'
 			]
 		}
 	});

--- a/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar._ProxyProperty.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar._ProxyProperty.js
@@ -4,7 +4,8 @@ exports.parse = function(node, state) {
 	_.extend(state, {
 		proxyPropertyDefinition: {
 			parents: [
-				'Ti.UI.Android.CollapseToolbar'
+				'Ti.UI.Android.CollapseToolbar',
+				'Ti.UI.iPad.Popover'
 			]
 		}
 	});

--- a/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.js
@@ -9,7 +9,7 @@ exports.parse = function(node, state) {
 function parse(node, state, args) {
 	const tiappSdkVersion = tiapp.getSdkVersion();
 	if (tiapp.version.lt(tiappSdkVersion, MIN_VERSION)) {
-		U.die(`Ti.UI.OptionBar requires Titanium SDK ${MIN_VERSION}+`);
+		U.die(`Ti.UI.Android.CollapseToolbar requires Titanium SDK ${MIN_VERSION}+`);
 	}
 
 	var children = U.XML.getElementsFromNodes(node.childNodes),

--- a/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.js
@@ -1,0 +1,34 @@
+const _ = require('lodash'),
+	U = require('../../../utils'),
+	MIN_VERSION = '12.1.0';
+
+exports.parse = function(node, state) {
+	return require('./base').parse(node, state, parse);
+};
+
+function parse(node, state, args) {
+	const tiappSdkVersion = tiapp.getSdkVersion();
+	if (tiapp.version.lt(tiappSdkVersion, MIN_VERSION)) {
+		U.die(`Ti.UI.OptionBar requires Titanium SDK ${MIN_VERSION}+`);
+	}
+
+	var children = U.XML.getElementsFromNodes(node.childNodes),
+		code = '',
+		extras = [],
+		proxyProperties = {};
+
+	// add all proxy properties at creation time
+	_.each(proxyProperties, function(v, k) {
+		extras.push([k, v]);
+	});
+
+	// if we got any extras, add them to the state
+	if (extras.length) {
+		state.extraStyle = styler.createVariableStyle(extras);
+	}
+
+	scrollViewState = require('./default').parse(node, state);
+	scrollViewState.code = code + scrollViewState.code;
+
+	return scrollViewState;
+}

--- a/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.js
@@ -27,8 +27,8 @@ function parse(node, state, args) {
 		state.extraStyle = styler.createVariableStyle(extras);
 	}
 
-	scrollViewState = require('./default').parse(node, state);
-	scrollViewState.code = code + scrollViewState.code;
+	viewState = require('./default').parse(node, state);
+	viewState.code = code + viewState.code;
 
-	return scrollViewState;
+	return viewState;
 }

--- a/Alloy/common/constants.js
+++ b/Alloy/common/constants.js
@@ -238,7 +238,6 @@ exports.IMPLICIT_NAMESPACES = {
 	ContentView: isTitanium && Ti.Platform.osname === 'android' ?
 		'Ti.UI.Android.CollapseToolbar' : 'Ti.UI.iPad.Popover',
 
-	ContentView: 'Ti.UI.Android.CollapseToolbar',
 	CollapseToolbar: 'Ti.UI.Android',
 
 	DrawerLayout: 'Ti.UI.Android',

--- a/Alloy/common/constants.js
+++ b/Alloy/common/constants.js
@@ -235,8 +235,11 @@ exports.IMPLICIT_NAMESPACES = {
 	TitleControl: 'Ti.UI.Window',
 	WindowToolbar: 'Ti.UI.Window',
 
-	// Ti.UI.iPad.Popover
-	ContentView: 'Ti.UI.iPad.Popover',
+	ContentView: isTitanium && Ti.Platform.osname === 'android' ?
+		'Ti.UI.Android.CollapseToolbar' : 'Ti.UI.iPad.Popover',
+
+	ContentView: 'Ti.UI.Android.CollapseToolbar',
+	CollapseToolbar: 'Ti.UI.Android',
 
 	DrawerLayout: 'Ti.UI.Android',
 	LeftView: 'Ti.UI.Android.DrawerLayout',


### PR DESCRIPTION
* Add `CollapseToolbar` to Alloy (copied over from `DrawerLayout`)

needed for https://github.com/tidev/titanium_mobile/pull/13760

```xml
<Alloy>
	<Window>

		<CollapseToolbar platform="android">

			<ContentView>
				<View backgroundColor="red" height="Ti.UI.SIZE">
					<Label>test</Label>
				</View>
			</ContentView>
		</CollapseToolbar>

	</Window>
</Alloy>
```