### PR TITLE
test: prefix bin to path to ensure local alloy is used

### DIFF
--- a/test/lib/testUtils.js
+++ b/test/lib/testUtils.js
@@ -19,7 +19,7 @@ exports.paths = {
 };
 
 function createEnv () {
-	return Object.assign(process.env, { PATH: `${process.env.PATH}${path.delimiter}${path.join(process.cwd(), 'bin')}`})
+	return Object.assign(process.env, { PATH: `${path.join(process.cwd(), 'bin')}${path.delimiter}${process.env.PATH}`})
 }
 
 // Recreate the test app harness


### PR DESCRIPTION
Executables are resolved first found in the path iirc, so prefixing is the right thing to do