### PR TITLE
feat: TSS @include

### DIFF
--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -287,6 +287,12 @@ exports.loadStyle = function(tssFile) {
 		// [ALOY-793] double-escape '\' in tss
 		contents = contents.replace(/(\s)(\\+)(\s)/g, '$1$2$2$3');
 
+		var regex = /@include[ \t]*[ \t]*['"](.*?)['"][ \t]*[ \t]*?;/;
+		while (match = regex.exec(contents)) {
+			var dir = path.dirname(tssFile);
+			contents = contents.replace(match[0], fs.readFileSync(path.join(dir, match[1]+ ".tss")));
+		}
+
 		// Process tss file then convert to JSON
 		var json;
 		try {

--- a/Alloy/commands/compile/styler.js
+++ b/Alloy/commands/compile/styler.js
@@ -287,6 +287,7 @@ exports.loadStyle = function(tssFile) {
 		// [ALOY-793] double-escape '\' in tss
 		contents = contents.replace(/(\s)(\\+)(\s)/g, '$1$2$2$3');
 
+		// able to use "@include './file'" in a TSS file
 		var regex = /@include[ \t]*[ \t]*['"](.*?)['"][ \t]*[ \t]*?;/;
 		while (match = regex.exec(contents)) {
 			var dir = path.dirname(tssFile);


### PR DESCRIPTION
use @include in a TSS file. It will replace the line with the content of the file during compiling:

```
@include './file';
```

Won't work with LiveView. Based on old ltss source code.