### PR TITLE
fix: missing includes

### DIFF
--- a/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.ContentView.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.ContentView.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 exports.parse = function(node, state) {
 	_.extend(state, {
 		proxyPropertyDefinition: {

--- a/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.js
+++ b/Alloy/commands/compile/parsers/Ti.UI.Android.CollapseToolbar.js
@@ -1,5 +1,6 @@
 const _ = require('lodash'),
 	U = require('../../../utils'),
+	tiapp = require('../../../tiapp'),
 	MIN_VERSION = '12.1.0';
 
 exports.parse = function(node, state) {


### PR DESCRIPTION
**Changes**
* add missing includes.

**Fixes**
Being able to use `<ContentView ns="Ti.UI.Android.CollapseToolbar">` in Alloy again.


---
**Sidenote**
Still have to find out why `isTitanium` is false and the `Titanium` namespace is not available in
https://github.com/tidev/alloy/blob/master/Alloy/common/constants.js#L238-L239
it used to work.