### PR TITLE
feat: download _alloy_ db

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Install dependencies
         run: npm ci
       - name: Lint
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nodeVersion: [ '16.x' ]
+        nodeVersion: [ '18.x' ]
         os: [ macos-latest ]
         tiSDK: [ latest ]
     steps:
@@ -47,4 +47,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: npm test
-      

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: '18'
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies

--- a/Alloy/alloy.js
+++ b/Alloy/alloy.js
@@ -81,6 +81,10 @@ program.command('purgetss')
 	.option('--modules', 'Copy or generate the corresponding CommonJS module into `./app/lib/` folder.')
 	.option('--vendor <arguments>', 'Use any of the following arguments to copy specific vendors: fa = Font Awesome, md = Material Design or f7 = Framework7 Icons');
 
+program.command('db')
+	.description('Fetches the default alloy database (_alloy_) from the device')
+	.option('get', 'Downloads the _alloy_ database to your app folder');
+
 program.command('info [type]', { hidden: true });
 
 program.command('debugger', { hidden: true });

--- a/Alloy/commands/db/index.js
+++ b/Alloy/commands/db/index.js
@@ -1,0 +1,32 @@
+const {
+	exec
+} = require('child_process');
+const U = require('../../utils');
+const tiapp = require('../../tiapp');
+
+module.exports = async function(args, program) {
+
+	try {
+		if (args.length === 0) {
+			execCommand('db');
+		} else {
+			args.forEach(command => {
+				switch (command) {
+					case 'get':
+						tiapp.init();
+						console.log('Downloading _alloy_ database to: ' + tiapp.getBundleId() + '.db');
+						execCommand('adb -d shell "run-as ' + tiapp.getBundleId() + ' cat /data/data/' + tiapp.getBundleId() + '/databases/_alloy_" > ' + tiapp.getBundleId() + '.db');
+						break;
+				}
+			});
+		}
+	} catch (error) {
+		//
+	}
+};
+
+function execCommand(currentCommand) {
+	exec(currentCommand, (error, response) => {
+		return console.log(response);
+	});
+}

--- a/Alloy/tiapp.js
+++ b/Alloy/tiapp.js
@@ -40,6 +40,12 @@ tiapp.getSdkVersion = function() {
 		}
 	}
 };
+tiapp.getBundleId = function() {
+	var elems = doc.documentElement.getElementsByTagName('id');
+	if (elems && elems.length > 0) {
+		return U.XML.getNodeText(elems.item(elems.length - 1));
+	}
+};
 function getSdkSelectVersion() {
 	var homeDir = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'],
 		file = path.join(homeDir, '.titanium', 'config.json');


### PR DESCRIPTION
Run `alloy db get` to download the `_alloy_` database to `bundle.id.db`

Only tested it on Android/Linux so far. It will use `adb` to download the file. Need to test it on iOS/Mac