### PR TITLE
fix: backbone 1.6.0 fixes

### DIFF
--- a/Alloy/common/constants.js
+++ b/Alloy/common/constants.js
@@ -47,7 +47,7 @@ exports.SKIP_EVENT_HANDLING = ['Ti.UI.ListItem', 'Alloy.Abstract.ItemTemplate'];
 exports.ADAPTERS = ['localStorage', 'properties', 'sql'];
 exports.CONTROLLER_NODES = ['Alloy.Require', 'Alloy.Widget'];
 exports.DEFAULT_BACKBONE_VERSION = '0.9.2';
-exports.SUPPORTED_BACKBONE_VERSIONS = ['0.9.2', '1.1.2', '1.3.3', '1.4.0', '1.5.0'];
+exports.SUPPORTED_BACKBONE_VERSIONS = ['0.9.2', '1.1.2', '1.3.3', '1.4.0', '1.6.0'];
 
 // property names
 exports.CLASS_PROPERTY = 'classes';

--- a/Alloy/lib/alloy/backbone/1.6.0/backbone.js
+++ b/Alloy/lib/alloy/backbone/1.6.0/backbone.js
@@ -22,7 +22,7 @@
 
   // Next for Node.js or CommonJS. jQuery may not be needed as a module.
   } else if (typeof exports !== 'undefined') {
-    var _ = require('underscore'), $;
+    var _ = require('/alloy/underscore'), $;
     try { $ = require('jquery'); } catch (e) {}
     factory(root, exports, _, $);
 


### PR DESCRIPTION
when switching from Backbone 1.5.0 to 1.6.0 in the last PR I forgot to update these two files in order to use underscore functions.

I most Backbone stuff was working but functions like `findWhere` didn't work.

After this fix everything is working again